### PR TITLE
[Diary] STOMP의 Native WebSocket으로 SockJS 대체

### DIFF
--- a/src/hooks/useDiaryWebSocket.ts
+++ b/src/hooks/useDiaryWebSocket.ts
@@ -1,6 +1,5 @@
 import { useEffect } from 'react';
 import { Client } from '@stomp/stompjs';
-import SockJS from 'sockjs-client';
 
 export const useDiaryWebSocket = (
   diaryId: string,
@@ -9,111 +8,42 @@ export const useDiaryWebSocket = (
 ) => {
   useEffect(() => {
     if (!diaryId) return;
-
-    let client: Client | null = null;
-    let isMounted = true;
-    let timeoutId: ReturnType<typeof setTimeout>;
-
-    (async () => {
-      try {
-        const res = await fetch(
-          `https://api.lumidiary.com/core/ws/images/session/${diaryId}`,
-          {
-            method: 'GET',
-            credentials: 'include', // 쿠키를 받기 위해 반드시 필요
-            headers: {
-              'Content-Type': 'application/json',
-            },
-          },
-        );
-        if (!res.ok)
-          throw new Error(`세션 준비 API 호출 실패 (HTTP ${res.status})`);
-        console.log('✅ 세션 준비 API 호출 성공');
-      } catch (err) {
-        console.error('❌ 세션 준비 API 호출 실패:', err);
-        return;
-      }
-
-      timeoutId = setTimeout(() => {
-        if (!isMounted) return;
-
-        // ⚠ withCredentials: true 로 설정해야 쿠키가 WebSocket 핸드셰이크에 붙음
-        const socket = new SockJS(
-          'https://api.lumidiary.com/core/ws',
-          // undefined,
-          // {
-          //   withCredentials: true,
-          // },
-        );
-        client = new Client({
-          webSocketFactory: () => socket,
-          reconnectDelay: 2000,
-          debug: msg => {
-            console.log('[STOMP DEBUG]', msg);
-            if (msg.includes('Opening Web Socket')) {
-              console.log('🛰️ WebSocket 연결 시도 중...');
+    let client: Client | null;
+    const baseUrl =
+      import.meta.env.VITE_SERVER_URL || 'https://api.lumidiary.com';
+    const wsProtocol = baseUrl.startsWith('https') ? 'wss' : 'ws';
+    const brokerURL = `${wsProtocol}://${baseUrl.replace(/^https?:\/\//, '')}/core/ws/websocket`;
+    client = new Client({
+      brokerURL,
+      reconnectDelay: 2000,
+      debug: msg => console.log('[STOMP DEBUG]', msg),
+      onConnect: () => {
+        console.log('🟢 WebSocket 연결 성공');
+        client?.subscribe(`/topic/diary/${diaryId}`, message => {
+          try {
+            const parsed = JSON.parse(message.body);
+            if (
+              parsed.type === 'ANALYSIS_COMPLETE' &&
+              typeof parsed.content === 'string'
+            ) {
+              const { overallDaySummary, questions } = JSON.parse(parsed.content);
+              onMessage({ overallDaySummary, questions });
+              client?.deactivate();
             }
-            if (msg.includes('Connection closed')) {
-              console.log('❌ WebSocket 연결이 닫혔습니다');
-            }
-            if (msg.includes('reconnection')) {
-              console.log('🔁 재연결 예정 (2초 후)');
-            }
-          },
-          onConnect: () => {
-            console.log('🟢 WebSocket 연결 성공');
-            const topic = `/topic/diary/${diaryId}`;
-            client?.subscribe(topic, message => {
-              try {
-                const parsed = JSON.parse(message.body);
-                console.log('메시지 수신됨:', parsed);
-                if (parsed.type === 'DISCONNECT_REQUEST') {
-                  console.warn('연결 해제 요청 수신. 2초 후 종료');
-                  setTimeout(() => {
-                    client?.deactivate();
-                  }, 2000);
-                }
-                onMessage(parsed);
-              } catch (err) {
-                console.error('WebSocket 메시지 파싱 실패:', err);
-              }
-            });
-          },
-          onStompError: frame => {
-            console.error('STOMP 에러 발생:', frame.headers.message);
-          },
+          } catch (e) {
+            console.error('메시지 파싱 실패:', e);
+          }
         });
-
-        client.activate();
-        console.log('WebSocket client.activate() 호출됨');
-
-        const handleBeforeUnload = () => {
-          if (client && client.active) {
-            client.deactivate();
-            console.log('브라우저 언로드: WebSocket 종료됨');
-          }
-        };
-        window.addEventListener('beforeunload', handleBeforeUnload);
-
-        // useEffect 클린업
-        return () => {
-          isMounted = false;
-          if (client && client.active) {
-            client.deactivate();
-            console.log('useEffect 클린업: WebSocket 종료');
-          }
-          window.removeEventListener('beforeunload', handleBeforeUnload);
-        };
-      }, 1000);
-    })();
-
+      },
+      onStompError: frame => {
+        console.error('STOMP 에러:', frame.headers.message);
+      },
+    });
+    client.activate();
+    window.addEventListener('beforeunload', () => client?.deactivate());
     return () => {
-      isMounted = false;
-      clearTimeout(timeoutId);
-      if (client && client.active) {
-        client.deactivate();
-        console.log('useEffect return: WebSocket 종료');
-      }
+      client?.deactivate();
+      window.removeEventListener('beforeunload', () => client?.deactivate());
     };
   }, [diaryId]);
 };

--- a/src/pages/diary/DiaryCreate.tsx
+++ b/src/pages/diary/DiaryCreate.tsx
@@ -29,29 +29,19 @@ const DiaryCreate = () => {
   const [, setIsAnalysisDone] = useState(false);
 
   const handleWsMessage = useCallback(
-    (parsed: { type: any; content: any; questions: any }) => {
-      const { type, content, questions } = parsed;
-      switch (type) {
-        case 'QUESTION':
-          if (Array.isArray(questions)) {
-            const questionTexts = questions.map(q => q.question);
-            console.log('[질문 수신됨]', questionTexts);
-            setQuestions(prev => [...prev, ...questions.map(q => q.question)]);
-            setQuestionIds(prev => [...prev, ...questions.map(q => q.id)]);
-          }
-          break;
-        case 'ANALYSIS_COMPLETE':
-          setIsAnalysisDone(true);
-          break;
-        case 'ERROR':
-          console.log('UNKNOWN 에러:', content);
-          break;
-        case 'DISCONNECT_REQUEST':
-          console.log('서버에서 연결 해제를 요청했습니다.');
-          break;
-        default:
-          console.log('UNKNOWN MESSAGE:', parsed);
-      }
+    ({
+      overallDaySummary,
+      questions: finalQs,
+    }: {
+      overallDaySummary: string;
+      questions: { id: string; question: string }[];
+    }) => {
+      console.log('[Summary]', overallDaySummary);
+      console.log('[Questions]', finalQs);
+      // extract question texts and ids
+      setQuestions(finalQs.map(q => q.question));
+      setQuestionIds(finalQs.map(q => q.id));
+      setIsAnalysisDone(true);
     },
     [],
   );


### PR DESCRIPTION
## 🗂️ Details

- SockJS 사용시 WebSocket 연결이 열리지 않는 문제가 있었음
- SockJS 대신 STOMP 클라이언트의 brokerURL 옵션으로 네이티브 WebSocket을 직접 연결

## ✅ Need Review

- 백엔드와 협의하여 웹소켓 반환타입을 한개로 통일
- 관련해서 콜백함수도 코드 수정이 있으므로 확인 부탁드립니다.
- 현재 콜백함수에서 응답내용을 콘솔에 출력하도록 되어있는데, UI적으로 처리하는 부분 구현해 주시면 될 것 같습니다.

## 📸 Screenshot

<img width="1552" alt="스크린샷" src="https://github.com/user-attachments/assets/29f986c3-c0b6-467d-beab-bc74e368b9f1" />
